### PR TITLE
Make tool `go get`-able

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module benchmarking
+module github.com/idealo/mongodb-benchmarking
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475


### PR DESCRIPTION
Valid module path is the only thing that prevents this tools from being `go get`-able to/ `go install`-able.